### PR TITLE
Removed AndroidOpenSSL, No casting to RSAprivateKey

### DIFF
--- a/app/src/main/java/com/sample/foo/simplekeystoreapp/MainActivity.java
+++ b/app/src/main/java/com/sample/foo/simplekeystoreapp/MainActivity.java
@@ -174,11 +174,11 @@ public class MainActivity extends AppCompatActivity {
 
     public void decryptString(String alias) {
         try {
-            KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(alias, null);
-            RSAPrivateKey privateKey = (RSAPrivateKey) privateKeyEntry.getPrivateKey();
 
-            Cipher output = Cipher.getInstance("RSA/ECB/PKCS1Padding", "AndroidOpenSSL");
-            output.init(Cipher.DECRYPT_MODE, privateKey);
+            KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry) keyStore.getEntry(alias, null);
+            Cipher output = Cipher.getInstance("RSA/ECB/PKCS1Padding");
+            output.init(Cipher.DECRYPT_MODE, privateKeyEntry.getPrivateKey());
+
 
             String cipherText = encryptedText.getText().toString();
             CipherInputStream cipherInputStream = new CipherInputStream(


### PR DESCRIPTION
Fixed the issue with Marshmallow:
- Removed AndroidOpenSSL (as a result of Marshmallow migration to BoringSSL)
- No more casting to RSAprivateKey
- More info: https://developer.android.com/preview/behavior-changes.html#behavior-apache-http-client
